### PR TITLE
 Fix README telemetry service URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Each successful POST is persisted so the app only reports a given version/OS com
 
 ### Telemetry endpoints
 
-- **Install reports:** `https://telemetry.pokemmo-tool.app/install`
-- **Aggregated stats:** `https://telemetry.pokemmo-tool.app/stats`
+- **Install reports:** `https://3s-telemetry-service.vercel.app/api/install`
+- **Aggregated stats:** `https://3s-telemetry-service.vercel.app/api/stats`
 
 Both routes accept an optional bearer token via the `Authorization` header. When the
 `POKEMMO_TOOL_TELEMETRY_KEY` environment variable is populated the desktop app includes

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -6,8 +6,8 @@ same service exposes aggregated install counts for the CLI tooling in
 
 ## Endpoints
 
-- **Install POST endpoint:** `https://telemetry.pokemmo-tool.app/install`
-- **Stats endpoint:** `https://telemetry.pokemmo-tool.app/stats`
+- **Install POST endpoint:** `https://3s-telemetry-service.vercel.app/api/install`
+- **Stats endpoint:** `https://3s-telemetry-service.vercel.app/api/stats`
 
 Both endpoints accept JSON responses and support bearer authentication. When the
 `POKEMMO_TOOL_TELEMETRY_KEY` environment variable is set the Electron app and CLI


### PR DESCRIPTION
The old URLs don't seem to exist. This updates the READMEs to list the correct telemetry URLs.